### PR TITLE
Fix a couple of compile errors on latest-release branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ARG GROUP_ID
 
 ENV DEBIAN_FRONTEND="noninteractive"
 
-RUN apt update && apt install -y build-essential python3-pip && pip install pandas requests openpyxl
+RUN apt update && apt install -y build-essential python3-pip && pip install pandas requests openpyxl --break-system-packages

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ clean:
 	@$(MAKE) -C tools/data-generator clean
 	@$(MAKE) -C loader clean
 	@rm -fr $(BUILD) $(TARGET).elf $(TARGET).gba data/ to_compress/
-	@rm text_helper/output.json
+	@rm -f text_helper/output.json
 
 
 

--- a/compress_lz10.sh
+++ b/compress_lz10.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 infile="$1"
 outfile="data/$(basename "$infile" .bin)_lz10.bin"
-if [ "$infile" -nt "$outfile" ]; then
+if [ ! -f "$outfile" ] || [ "$infile" -nt "$outfile" ]; then
     gbalzss e "$infile" "$outfile"
     echo -n "C"
 else

--- a/tools/data-generator/include/extern_pokemon_data.h
+++ b/tools/data-generator/include/extern_pokemon_data.h
@@ -7,10 +7,12 @@
 #define NUM_POKEMON 252
 #define POKEMON_ARRAY_SIZE NUM_POKEMON + 1
 
+#ifndef TONC_TYPES
 typedef uint8_t u8;
 typedef uint8_t byte;
 typedef uint16_t u16;
 typedef uint32_t u32;
+#endif
 
 void generate_pokemon_data(const char *output_path);
 


### PR DESCRIPTION
- Fix make clean by adding -f flag when removing output.json

- Fix broken compress_lz10.sh script: it had a check to avoid compressing when the input bin file hasn't changed. But the -nt operator also returns false if the output file doesn't exist.

- Fix compilation error on conflicting u32 typedef: libtonc defines one and so does data-generator. We shouldn't redefine it if the one from libtonc exists. The one in data-generator exists for compiling the tool for pc.

- Fix Dockerfile. For some reason the Dockerfile was now failing because Ubuntu manages the python pip packages. I fixed it with the --break-system-packages shortcut. It should be fine.