### PR TITLE
Fix language support branch build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ARG GROUP_ID
 
 ENV DEBIAN_FRONTEND="noninteractive"
 
-RUN apt update && apt install -y build-essential python3-pip && pip install pandas requests openpyxl
+RUN apt update && apt install -y build-essential python3-pip && pip install pandas requests openpyxl --break-system-packages

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ clean:
 	@$(MAKE) -C tools/data-generator clean
 	@$(MAKE) -C loader clean
 	@rm -fr $(BUILD) $(TARGET).elf $(TARGET).gba data/ to_compress/
-	@rm text_helper/output.json
+	@rm -f text_helper/output.json
 
 
 

--- a/compress_lz10.sh
+++ b/compress_lz10.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 infile="$1"
 outfile="data/$(basename "$infile" .bin)_lz10.bin"
-if [ "$infile" -nt "$outfile" ]; then
+if [ ! -f "$outfile" ] || [ "$infile" -nt "$outfile" ]; then
     gbalzss e "$infile" "$outfile"
     echo -n "C"
 else

--- a/tools/data-generator/include/extern_pokemon_data.h
+++ b/tools/data-generator/include/extern_pokemon_data.h
@@ -7,10 +7,12 @@
 #define NUM_POKEMON 252
 #define POKEMON_ARRAY_SIZE NUM_POKEMON + 1
 
+#ifndef TONC_TYPES
 typedef uint8_t u8;
 typedef uint8_t byte;
 typedef uint16_t u16;
 typedef uint32_t u32;
+#endif
 
 void generate_pokemon_data(const char *output_path);
 

--- a/tools/data-generator/src/main.cpp
+++ b/tools/data-generator/src/main.cpp
@@ -109,7 +109,7 @@ void generate_payloads_for(uint8_t generation, bool yellow_version, const char *
 
 void test_payloads(const char *full_path)
 {
-    uint8_t buffer[2048]; // 2048 bytes is enough for the payloads
+    uint8_t buffer[4096]; // 4096 bytes is enough for the payloads
     uint8_t reference_payload_buffer[PAYLOAD_SIZE];
     uint8_t reconstructed_payload_buffer[PAYLOAD_SIZE];
     FILE *file;


### PR DESCRIPTION
This pull request fixes the data-generator crash.

Problem: when I first implemented data-generator, I defined a 2 KB buffer for test_payloads() in data-generator/src/main.cpp. I assumed this was large enough.

But turns out the filesize has increased to 2.2 KB for the gen2 payloads file since then. (don't know why though).

Fix: increase the buffer to 4 KB.

Note: this pull request also includes the changes of https://github.com/GearsProgress/Poke_Transporter_GB/pull/73
(these weren't merged to your language-support branch yet).

The actual change I did, specific to this pull request, is in tools/data-generator/src/main.cpp