### PR TITLE
Copy loader.gba to the root folder and rename to Poke_Transporter_GB_standalone.gba at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ LIBPCCS := $(CURDIR)/PCCS
 #
 #---------------------------------------------------------------------------------
 TARGET		:= $(notdir $(CURDIR))_mb
+LOADERNAME  := $(notdir $(CURDIR))_standalone
 BUILD		:= build
 SOURCES     := source
 INCLUDES    := include PCCS/lib/include
@@ -189,6 +190,7 @@ $(BUILD): generate_data
 	@mkdir -p loader/data
 	@cp $(TARGET).gba loader/data/multiboot_rom.bin
 	@$(MAKE) -C loader
+	@cp loader/loader.gba $(LOADERNAME).gba
 
 #---------------------------------------------------------------------------------
 clean:
@@ -196,7 +198,7 @@ clean:
 	@$(MAKE) -C tools/payload-generator clean
 	@$(MAKE) -C loader clean
 	@$(MAKE) -C PCCS clean
-	@rm -fr $(BUILD) $(TARGET).elf $(TARGET).gba data/ to_compress/
+	@rm -fr $(BUILD) $(TARGET).elf $(TARGET).gba $(LOADERNAME).gba data/ to_compress/
 	@rm -f text_helper/output.json
 
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,23 @@ Poke Transporter GB supports original gen III cartridges AND the gen III games i
 Poké Transporter GB is a Multiboot program for the Game Boy Advance.
 
 There are 3 main ways to run the Poké Transporter GB ROM on a Game Boy Advance:
-- Use a program such as FIX94's [GBA Link Cable ROM Sender](https://github.com/FIX94/gba-link-cable-rom-sender) on a GameCube or Wii running Homebrew along with a GBA GameCube Link Cable
-- Upload the Multiboot ROM to a GBA Flash Cart, launch the game in Multiboot mode (often by holding L when selecting the ROM), and swap the Game Pak after the program loads.
-- Copy the loader.gba file to a GBA Flash Cart and swap the Game Pak after the program loads. This is useful for flashcarts that don't support launching multiboot roms directly (SuperCard SD for example), although it should work on any flashcart.
+- Use a program such as FIX94's [GBA Link Cable ROM Sender](https://github.com/FIX94/gba-link-cable-rom-sender) on a GameCube or Wii running Homebrew along with a GBA GameCube Link Cable to send the Multiboot rom (Poke_Transporter_GB_mb.gba) to the gba over the link cable.
+
+- Upload the Multiboot ROM (Poke_Transporter_GB_mb.gba) to a GBA Flash Cart, launch the game in Multiboot mode (often by holding L when selecting the ROM), and swap the Game Pak after the program loads.
+
+- Copy the Loader ROM (Poke_Transporter_GB_standalone.gba) to a GBA Flash Cart and swap the Game Pak after the program loads. This is useful for flashcarts that don't support launching multiboot roms directly (SuperCard SD for example), although it should work on any flashcart.
 
 EZ Flash Omega DE users, read [this](docs/EZ_Flash_Omega_DE.md)!
 
 Please note that transfering Pokémon will only work with a Game Boy Color Link Cable. Game Boy Advance Link Cables will not work.
+
+NOTE: If you're using the Loader ROM (Poke_Transporter_GB_standalone.gba) instead of the Multiboot ROM (Poke_Transporter_GB_mb.gba),
+you could run into trouble when swapping in the gen3 cartridge: Some cartridges cause the GBA to reset when inserted.
+
+If you have this problem, you could:
+- Use the Multiboot ROM (Poke_Transporter_GB_mb.gba) instead (as described above)
+
+- Use the 2 GBA method as described [here](docs/EZ_Flash_Omega_DE.md#method-2-2-gbas)
 
 ## Modifications to Transfered Pokémon
 

--- a/docs/EZ_Flash_Omega_DE.md
+++ b/docs/EZ_Flash_Omega_DE.md
@@ -43,10 +43,10 @@ Requirements:
 - Gameboy Color link cable
 
 Steps:
-- Make sure the loader.gba is stored on the microSD card of the EZ Flash Omega DE
+- Make sure the Poke_Transporter_GB_standalone.gba is stored on the microSD card of the EZ Flash Omega DE
 - Make sure the pokémon game is stored on your EZ Flash' NOR flash.
 - Make sure the physical switch on the EZ Flash is set to mode A (the menu should show)
-- Insert the EZ Flash in GBA 1 and launch loader.gba.
+- Insert the EZ Flash in GBA 1 and launch Poke_Transporter_GB_standalone.gba
 - Press START on the splash screen. This popup should show:
 ![multiboot popup 1](images/multiboot_popup_1.png)
 - Press SELECT. This popup should show:


### PR DESCRIPTION
This avoids forgetting about it when doing a release.

I also modified the documentation to reflect this new name.

BONUS change: I also documented the cartridge swap reset problem in the README.md