### PR TITLE
Fix some build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM devkitpro/devkitarm
+FROM devkitpro/devkitarm:20251117
 
 LABEL author="Poke Transporter GB"
 

--- a/tools/text_helper/main.py
+++ b/tools/text_helper/main.py
@@ -617,7 +617,7 @@ def generate_cpp_file():
         cppFile.write("\nconst u8* get_compressed_text_table(int table_index)\n")
 
         for i, lang in enumerate(Languages):
-            cppFile.write(f"\n#{"el" if i > 0 else ""}if PTGB_BUILD_LANGUAGE == {lang.value + 1}\n")
+            cppFile.write(f"\n#{'el' if i > 0 else ''}if PTGB_BUILD_LANGUAGE == {lang.value + 1}\n")
             cppFile.write("{\n")
             cppFile.write("\tswitch (table_index)\n\t{\n")
             for section in textSections:


### PR DESCRIPTION
Problem 1: syntax error in text_helper
Fix 1: single quotes instead of double quotes

Problem 2: the ground shifted beneath our feet with the devkitpro/devkitARM base image again. The --break-system-packages option no longer exists on pip install. Fix 2: Use a specific tag of the devkitpro/devkitARM docker image to ensure this won't happen again.