### PR TITLE
Fix text_helper build issue if you build with multiple jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ $(GENERATE_STAMP): $(TEXT_HELPER_INPUTS) $(PAYLOAD_GEN_INPUTS) compress_lz10.sh 
 	@touch $@
 
 #---------------------------------------------------------------------------------
-$(BUILD_STAMP): $(GENERATE_STAMP) $(TEXT_GENERATED_OUTPUTS) | $(BUILD)
+$(BUILD_STAMP): $(GENERATE_STAMP) | $(BUILD)
 	@$(MAKE) -C PCCS \
 		CC="$(CC)" \
 		CXX="$(CXX)" \


### PR DESCRIPTION
This issue looked like this:

make[1]: *** No rule to make target 'build/generated/translated_text.h', needed by 'build/.build.english.release.stamp'. Stop.
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:210: all] Error 2

It was a dependency issue.