### PR TITLE
Fix MGBA logging bug

### DIFF
--- a/include/dbg/ptgb_mgba_print.h
+++ b/include/dbg/ptgb_mgba_print.h
@@ -11,11 +11,11 @@ extern "C" {
 #define PTGB_MGBA_LOG_INFO 3
 #define PTGB_MGBA_LOG_DEBUG 4
 
-#define PTGB_MGBA_FATAL(X, ...) ptgb_mgba_print(PTGB_MGBA_LOG_FATAL, X, ##__VA_ARGS__)
-#define PTGB_MGBA_ERROR(X, ...) ptgb_mgba_print(PTGB_MGBA_LOG_ERROR, X, ##__VA_ARGS__)
-#define PTGB_MGBA_WARN(X, ...) ptgb_mgba_print(PTGB_MGBA_LOG_WARN, X, ##__VA_ARGS__)
-#define PTGB_MGBA_INFO(X, ...) ptgb_mgba_print(PTGB_MGBA_LOG_INFO, X, ##__VA_ARGS__)
-#define PTGB_MGBA_DEBUG(X, ...) ptgb_mgba_print(PTGB_MGBA_LOG_DEBUG, X, ##__VA_ARGS__)
+#define PTGB_MGBA_FATAL(...) ptgb_mgba_print(PTGB_MGBA_LOG_FATAL, __VA_ARGS__)
+#define PTGB_MGBA_ERROR(...) ptgb_mgba_print(PTGB_MGBA_LOG_ERROR, __VA_ARGS__)
+#define PTGB_MGBA_WARN(...) ptgb_mgba_print(PTGB_MGBA_LOG_WARN, __VA_ARGS__)
+#define PTGB_MGBA_INFO(...) ptgb_mgba_print(PTGB_MGBA_LOG_INFO, __VA_ARGS__)
+#define PTGB_MGBA_DEBUG(...) ptgb_mgba_print(PTGB_MGBA_LOG_DEBUG, __VA_ARGS__)
 
 void ptgb_mgba_init(void);
 void ptgb_mgba_deinit(void);

--- a/include/libraries/libmgba/mgba.h
+++ b/include/libraries/libmgba/mgba.h
@@ -23,6 +23,8 @@
 #ifndef MGBA_H
 #define MGBA_H
 
+#include <stdarg.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -37,6 +39,7 @@ bool mgba_open(void);
 void mgba_close(void);
 
 void mgba_printf(int level, const char* string, ...);
+void mgba_vprintf(int level, const char* string, va_list args);
 bool mgba_console_open(void);
 
 #ifdef __cplusplus

--- a/source/libraries/libmgba/mgba.c
+++ b/source/libraries/libmgba/mgba.c
@@ -51,13 +51,17 @@ ssize_t mgba_stderr_write(struct _reent* r __attribute__((unused)), void* fd __a
 	return len;
 }
 
-void mgba_printf(int level, const char* ptr, ...) {
+void mgba_vprintf(int level, const char* ptr, va_list args) {
 	level &= 0x7;
+	npf_vsnprintf(REG_DEBUG_STRING, 0x100, ptr, args);
+	*REG_DEBUG_FLAGS = level | 0x100;
+}
+
+void mgba_printf(int level, const char* ptr, ...) {
 	va_list args;
 	va_start(args, ptr);
-	npf_vsnprintf(REG_DEBUG_STRING, 0x100, ptr, args);
+	mgba_vprintf(level, ptr, args);
 	va_end(args);
-	*REG_DEBUG_FLAGS = level | 0x100;
 }
 
 static const devoptab_t dotab_mgba_stdout = {


### PR DESCRIPTION
va args passing was broken in my initial implementation, causing garbage values to get printed whenever you'd try to print an actual argument.

Moreover, I also had a bug in the PTGB_MGBA_XYZ macros.

Sorry, I should've tested it with actual arguments.