### PR TITLE
Fix injection bugs + important regression bug.

### DIFF
--- a/include/dbg/debug_mode.h
+++ b/include/dbg/debug_mode.h
@@ -109,7 +109,7 @@ extern debug_options g_debug_options;
 #define POKEMON_INDEX_TO_SKIP 5
 
 // not sure if we want these in the debug menu.
-#define DEBUG_GAME RUBY_ID
+#define DEBUG_GAME EMERALD_ID
 #define DEBUG_VERS VERS_1_0
 #define DEBUG_LANG LANG_ENG
 

--- a/include/dbg/debug_mode.h
+++ b/include/dbg/debug_mode.h
@@ -109,7 +109,7 @@ extern debug_options g_debug_options;
 #define POKEMON_INDEX_TO_SKIP 5
 
 // not sure if we want these in the debug menu.
-#define DEBUG_GAME EMERALD_ID
+#define DEBUG_GAME RUBY_ID
 #define DEBUG_VERS VERS_1_0
 #define DEBUG_LANG LANG_ENG
 
@@ -127,6 +127,6 @@ extern debug_options g_debug_options;
 // Compiling with this option enabled in release builds will cause a static_assert failure.
 // But the && DEBUG_MODE check will already prevent this from being enabled in release builds accidentally,
 // so as long as no-one removes that, it should be fine.
-#define DEBUG_USE_MGBA_PRINT (true && DEBUG_MODE)
+#define DEBUG_USE_MGBA_PRINT (false && DEBUG_MODE)
 
 #endif

--- a/source/Gen3CartridgeSaveReader.cpp
+++ b/source/Gen3CartridgeSaveReader.cpp
@@ -143,6 +143,8 @@ void Gen3CartridgeSaveReader::flush()
     }
 
     update_memory_buffer_checksum(sector_buffer_, (sector_start_ == HALL_OF_FAME));
+    // Real flash requires erase before rewriting bytes that may need 0->1 transitions.
+    erase_sector(sector_start_);
     copy_ram_to_save(sector_buffer_, sector_start_, SECTOR_SIZE);
     dirty_ = false;
 }

--- a/source/flash_mem.cpp
+++ b/source/flash_mem.cpp
@@ -22,11 +22,19 @@ void initialize_memory_locations()
     u8 save_B_index[4];
     copy_save_to_ram(SAVE_A_OFFSET + SAVE_INDEX_OFFSET, &save_A_index[0], 0x04);
     copy_save_to_ram(SAVE_B_OFFSET + SAVE_INDEX_OFFSET, &save_B_index[0], 0x04);
-    reverse_endian(&save_A_index[0], 0x04);
-    reverse_endian(&save_B_index[0], 0x04);
+
+    // Save indices are little-endian in-sector; decode directly without byte swapping.
+    const u32 saveAIndex = static_cast<u32>(save_A_index[0]) |
+                           (static_cast<u32>(save_A_index[1]) << 8) |
+                           (static_cast<u32>(save_A_index[2]) << 16) |
+                           (static_cast<u32>(save_A_index[3]) << 24);
+    const u32 saveBIndex = static_cast<u32>(save_B_index[0]) |
+                           (static_cast<u32>(save_B_index[1]) << 8) |
+                           (static_cast<u32>(save_B_index[2]) << 16) |
+                           (static_cast<u32>(save_B_index[3]) << 24);
 
     // Determines if save A or B is more recent
-    if (*(vu32 *)save_B_index > *(vu32 *)save_A_index)
+    if (saveBIndex > saveAIndex)
     {
         newest_save_offset = SAVE_B_OFFSET;
     }

--- a/source/flash_mem.cpp
+++ b/source/flash_mem.cpp
@@ -131,14 +131,15 @@ void update_memory_buffer_checksum(u8 *sector_buffer, bool hall_of_fame)
     // source: https://bulbapedia.bulbagarden.net/wiki/Save_data_structure_(Generation_III)#Section_ID
     const u32 num_of_bytes = (sector_buffer[SECTION_ID_OFFSET] != 13) ? 3968 : 2000;
 
-    // the cpu is little endian and the data is read as little endian too.
-    // therefore, we can do a straightforward sum of the data as u32's.
-    const u32 *cur = (const u32 *)sector_buffer;
-    const u32 * const end = (const u32 *)(sector_buffer + num_of_bytes);
-    while (cur < end)
+    // Assemble words manually to avoid alignment and aliasing issues when the
+    // sector buffer is only guaranteed to be byte-aligned. So not 32-bit aligned.
+    for (u32 offset = 0; offset < num_of_bytes; offset += sizeof(u32))
     {
-        checksum += *cur;
-        ++cur;
+        const u32 cur = static_cast<u32>(sector_buffer[offset]) |
+                        (static_cast<u32>(sector_buffer[offset + 1]) << 8) |
+                        (static_cast<u32>(sector_buffer[offset + 2]) << 16) |
+                        (static_cast<u32>(sector_buffer[offset + 3]) << 24);
+        checksum += cur;
     }
 
     const u16 small_checksum = ((checksum & 0xFFFF0000) >> 16) + (checksum & 0x0000FFFF);


### PR DESCRIPTION
This pull request fixes various injection bugs (mostly PCCS).

But it also fixes a regression which I personally introduced.

I had modified flash_mem.cpp->update_memory_buffer_checksum() to loop through the buffer with pointer-based math to calculate the checksum. I assumed that sector_buffer would be 32-bit aligned. But I was wrong. Apparently that's not guarantueed when you declare it as a u8*. Therefore the checksum would calculate (and therefore write) a wrong value in practice.

Fix: read individual bytes.