### PR TITLE
Feature/unlock mystery gift

### DIFF
--- a/include/dbg/debug_menu_functions.h
+++ b/include/dbg/debug_menu_functions.h
@@ -33,4 +33,6 @@ void dbg_play_song(void *context, unsigned user_param);
  */
 void dbg_inject_pkmn(void *context, unsigned user_param);
 
+void dbg_unlock_mystery(void *context, unsigned user_param);
+
 #endif

--- a/include/dbg/debug_mode.h
+++ b/include/dbg/debug_mode.h
@@ -117,6 +117,7 @@ extern debug_options g_debug_options;
 #define ENABLE_DEBUG_MENU true
 #define ENABLE_TEXT_DEBUG_SCREEN true
 #define ENABLE_DEBUG_PKMN_INJECTION true
+#define ENABLE_MYSTERY_GIFT true
 #define USE_CUSTOM_MALLOC 1
 // needs to be a value divisible by 4
 #define CUSTOM_MALLOC_POOL_SIZE 8192

--- a/source/dbg/debug_menu_entries.cpp
+++ b/source/dbg/debug_menu_entries.cpp
@@ -103,6 +103,10 @@ void fill_debug_menu_with_entries(vertical_menu &menu, u16 *charset)
 #if ENABLE_DEBUG_PKMN_INJECTION
         define_executable_row(charset, "Inject Celebi", dbg_inject_pkmn, 0, nullptr),
 #endif
+#if ENABLE_MYSTERY_GIFT
+        define_executable_row(charset, "Unlock MystE", dbg_unlock_mystery, 0, nullptr),
+        define_executable_row(charset, "Unlock MystG", dbg_unlock_mystery, 1, nullptr),
+#endif
         define_song_row(charset, "Song"),
         define_toggle_row(charset, "Print Link", dbg_set_boolean_flag, g_debug_options.print_link_data, &g_debug_options.print_link_data),
         define_toggle_row(charset, "Instant Text", dbg_set_boolean_flag, g_debug_options.instant_text_speed, &g_debug_options.instant_text_speed),

--- a/source/dbg/debug_menu_functions.cpp
+++ b/source/dbg/debug_menu_functions.cpp
@@ -280,3 +280,34 @@ void dbg_inject_pkmn(void *context, unsigned user_param)
     hide_textbox();
     tte_erase_rect(LEFT, TOP, RIGHT, BOTTOM);
 }
+
+void dbg_unlock_mystery(void *context, unsigned user_param)
+{
+    const Game game_type = convert_rom_game_id_to_ptgb_game(curr_GBA_rom.gamecode);
+    const Language game_lang = convert_rom_lang_to_ptgb_lang(curr_GBA_rom.language);
+    Gen3CartridgeSaveReader reader(global_memory_buffer);
+    Gen3SaveManager save_manager(game_type, game_lang, reader);
+
+    if(user_param == 0)
+    {
+        // mystery event not supported by fire red or leaf green
+        if(game_type == FIRERED || game_type == LEAFGREEN)
+        {
+            return;
+        }
+    }
+    else
+    {
+        // mystery gift not supported by ruby or sapphire
+        if(game_type == RUBY || game_type == SAPPHIRE)
+        {
+            return;
+        }
+    }
+
+    save_manager.setMysteryEventUnlocked(user_param == 0);
+    save_manager.setMysteryGiftUnlocked(user_param != 0);
+
+    save_manager.finishSave();
+    reader.flush();
+}


### PR DESCRIPTION
This pull request adds 2 debug menu entries to unlock either Mystery Gift or Mystery Events.

NOTE: if you try to use this with the ignore_game_pak option (for example in the mgba emulator), then make sure to set DEBUG_GAME right!